### PR TITLE
add -triple aarch64 for macos builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC := clang
 AS := llvm-mc
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T link.T
 CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I include/
-AS_FLAGS := -arch=aarch64
+AS_FLAGS := -arch=aarch64 -triple=aarch64
 PYTHON2 := python2
 MEPHISTO := ctu
 RUBY := ruby

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC := clang
 AS := llvm-mc
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T link.T
 CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I include/
-AS_FLAGS := -arch=aarch64 -triple=aarch64
+AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch
 PYTHON2 := python2
 MEPHISTO := ctu
 RUBY := ruby


### PR DESCRIPTION
I hit the same issue in #8, and after a lot of trial and error, I found that adding:
```
-triple aarch64
```
to `AS_FLAGS` in the Makefile got me past it. I don't think this has any negative impact on the linux build, but haven't done a lot of testing with it.

After this change, it error'd at the python script (even after installing requirements), which I resolved by changing `PYTHON2 := python2` to `PYTHON2 := python`. That could be an issue with my environment, but it might be useful to note here as well.

After those two changes (the one in this PR and the python above), the test_bsd.nro file built