### PR TITLE
Add cloning instruction in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Libtransistor is a userland library for the Nintendo Switch. Currently, binaries
 
 ## Building
 
+First, clone the repo with
+
+```
+git clone --recursive https://github.com/reswitched/libtransistor
+```
+
 You will need Python 2 and the python packages listed in [`requirements.txt`](https://github.com/reswitched/libtransistor/blob/master/requirements.txt). You'll also need clang and lld (llvm linker).
 
 You *should* just be able to run `make`. If that doesn't work, submit an issue (or pull request). This will produce a number of `nro` and `nso` files in `build/test/`. These are binaries for the Nintendo Switch. NRO files are relocatable shared objects suitable for use with [ROhan](https://reswitched.tech/rohan). Both NRO and NSO binaries can be run under Mephisto, but NSO binaries don't get relocated properly at the moment and will crash pretty quickly.


### PR DESCRIPTION
Cloning requires using the unconventional `--recursive` flag to ensure the submodules are getting cloned as well.