### PR TITLE
Add LLVM_POSTFIX variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-LD := ld.lld
-CC := clang
-AS := llvm-mc
+LD := ld.lld$(LLVM_POSTFIX)
+CC := clang$(LLVM_POSTFIX)
+AS := llvm-mc$(LLVM_POSTFIX)
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T link.T
 CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I include/ -I newlib/newlib/libc/include/ -I newlib/newlib/libc/sys/switch/include/ -Wall
 AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch
@@ -13,11 +13,11 @@ libtransistor_TESTS := malloc bsd_ai_packing bsd sfdnsres nv
 libtransistor_OBJECTS := build/lib/svc.o build/lib/ipc.o build/lib/tls.o build/lib/util.o build/lib/ipc/sm.o build/lib/ipc/bsd.o build/lib/ipc/nv.o
 
 # for building newlib
-export AR_FOR_TARGET = llvm-ar
-export AS_FOR_TARGET = llvm-mc -arch=aarch64 -mattr=+neon
-export LD_FOR_TARGET = ld.lld
-export RANLIB_FOR_TARGET = llvm-ranlib
-export CC_FOR_TARGET = clang -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -ccc-gcc-name aarch64-switch-gcc -Wno-unused-command-line-argument
+export AR_FOR_TARGET = llvm-ar$(LLVM_POSTFIX)
+export AS_FOR_TARGET = llvm-mc$(LLVM_POSTFIX) -arch=aarch64 -mattr=+neon
+export LD_FOR_TARGET = ld.lld$(LLVM_POSTFIX)
+export RANLIB_FOR_TARGET = llvm-ranlib$(LLVM_POSTFIX)
+export CC_FOR_TARGET = clang$(LLVM_POSTFIX) -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -ccc-gcc-name aarch64-switch-gcc -Wno-unused-command-line-argument
 
 .SUFFIXES: # disable built-in rules
 


### PR DESCRIPTION
The LLVM_POSTFIX variable can be passed with make to match the installed version of clang. eg 'make -j 8 LLVM_POSTFIX=-5.0'