### PR TITLE
Add SSP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 *~
 build/
 projects/*
+
+# Ignore binary files
+*.o
+*.a
+*.so
+*.nso
+*.nro

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
-LIBTRANSISTOR_HOME=./
-
 include libtransistor.mk
 
-libtransistor_TESTS := malloc bsd_ai_packing bsd sfdnsres nv helloworld hid hexdump args
+libtransistor_TESTS := malloc bsd_ai_packing bsd sfdnsres nv helloworld hid hexdump args ssp
 libtransistor_OBJECT_NAMES := crt0_common.o svc.o ipc.o tls.o util.o ipc/sm.o ipc/bsd.o ipc/nv.o ipc/hid.o ipc/ro.o hid.o context.o
 libtransistor_OBJECT_FILES := $(addprefix $(LIBTRANSISTOR_HOME)/build/lib/,$(libtransistor_OBJECT_NAMES))
 
@@ -12,6 +10,7 @@ export AS_FOR_TARGET = llvm-mc$(LLVM_POSTFIX) -arch=aarch64 -mattr=+neon
 export LD_FOR_TARGET = ld.lld$(LLVM_POSTFIX)
 export RANLIB_FOR_TARGET = llvm-ranlib$(LLVM_POSTFIX)
 export CC_FOR_TARGET = clang$(LLVM_POSTFIX) -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -ccc-gcc-name aarch64-switch-gcc -Wno-unused-command-line-argument -isystem $(realpath $(LIBTRANSISTOR_HOME))/include/
+export CC_FLAGS_FOR_TARGET = $(CC_FLAGS)
 
 .SUFFIXES: # disable built-in rules
 
@@ -23,6 +22,9 @@ run_bsd_test: $(LIBTRANSISTOR_HOME)/build/test/test_bsd.nro $(LIBTRANSISTOR_HOME
 	$(RUBY) $(LIBTRANSISTOR_HOME)/test_helpers/bsd.rb $(MEPHISTO)
 
 run_sfdnsres_test: $(LIBTRANSISTOR_HOME)/build/test/test_sfdnsres.nro
+	$(MEPHISTO) --enable-sockets --load-nro $<
+
+run_ssp_test: $(LIBTRANSISTOR_HOME)/build/test/test_ssp.nro
 	$(MEPHISTO) --enable-sockets --load-nro $<
 
 run_%_test: $(LIBTRANSISTOR_HOME)/build/test/test_%.nro
@@ -64,5 +66,15 @@ $(LIBTRANSISTOR_HOME)/newlib/Makefile:
 $(LIBTRANSISTOR_HOME)/newlib/aarch64-none-switch/newlib/libc.a: $(LIBTRANSISTOR_HOME)/newlib/Makefile
 	make -C $(LIBTRANSISTOR_HOME)/newlib/
 
+$(LIBTRANSISTOR_HOME)/libssp/libssp.a:
+	make -C $(LIBTRANSISTOR_HOME)/libssp
+
+.PHONY: clean
 clean:
 	rm -rf $(LIBTRANSISTOR_HOME)/build/lib/* $(LIBTRANSISTOR_HOME)/build/test/*
+	make -C libssp clean
+
+.PHONY: clean_newlib
+clean_newlib:
+	make -C newlib clean
+	rm -rf newlib/aarch64-none-switch

--- a/lib/crt0_common.c
+++ b/lib/crt0_common.c
@@ -7,6 +7,8 @@
 #include<stdio.h>
 #include<string.h>
 
+#include<ssp/ssp.h>
+
 int main(int argc, char **argv);
 
 // from util.c
@@ -203,6 +205,9 @@ int _libtransistor_start(libtransistor_context_t *ctx, void *aslr_base) {
   if(libtransistor_context->has_bsd && libtransistor_context->std_socket > 0 && !dont_finalize_bsd) {
     bsd_finalize();
   }
+
+  __guard_setup();
+
   return ret;
 }
 

--- a/lib/crt0_common.c
+++ b/lib/crt0_common.c
@@ -129,6 +129,8 @@ int _libtransistor_start(libtransistor_context_t *ctx, void *aslr_base) {
     return -4;
   }
   
+  __guard_setup();
+
   dbg_printf("aslr base: %p", aslr_base);
   dbg_printf("ctx: %p", ctx);
 
@@ -205,8 +207,6 @@ int _libtransistor_start(libtransistor_context_t *ctx, void *aslr_base) {
   if(libtransistor_context->has_bsd && libtransistor_context->std_socket > 0 && !dont_finalize_bsd) {
     bsd_finalize();
   }
-
-  __guard_setup();
 
   return ret;
 }

--- a/libssp/Makefile
+++ b/libssp/Makefile
@@ -1,0 +1,28 @@
+# Pull target toolchain, otherwise use native system toolchain
+ifneq ($(AR_FOR_TARGET),)
+AR := $(AR_FOR_TARGET)
+endif
+
+ifneq ($(CC_FOR_TARGET),)
+CC := $(CC_FOR_TARGET)
+endif
+
+ifneq ($(CC_FLAGS_FOR_TARGET),)
+CC_FLAGS := $(CC_FLAGS_FOR_TARGET)
+endif
+
+.SUFFIXES: # disable built-in rules
+
+%.o: %.c
+	@$(CC) $(CC_FLAGS) -c -o $@ $<
+	@echo [CC] $@
+
+all: libssp.a
+
+libssp.a: ssp.o
+	@$(AR) rcs $@ $<
+	@echo [AR] $@
+
+.PHONY: clean
+clean:
+	rm -rf *.a *.o

--- a/libssp/include/ssp/ssp.h
+++ b/libssp/include/ssp/ssp.h
@@ -1,0 +1,40 @@
+/* Object size checking support macros.
+   Copyright (C) 2004-2017 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+In addition to the permissions in the GNU General Public License, the
+Free Software Foundation gives you unlimited permission to link the
+compiled version of this file into combinations with other programs,
+and to distribute those combinations without any restriction coming
+from the use of this file.  (The General Public License restrictions
+do apply in other respects; for example, they cover modification of
+the file, and distribution when not linked into a combine
+executable.)
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
+#ifndef _SSP_H
+#define _SSP_H
+
+void __guard_setup(void);
+void __chk_fail(void) __attribute__((noreturn));
+
+#endif

--- a/libssp/ssp.c
+++ b/libssp/ssp.c
@@ -58,12 +58,13 @@ static void fail(const char *msg1, const char *msg2)
 {
 	// Print error message directly to the tty. This avoids Bad Things
 	//   happening if stderr is redirected.
+	printf("%s", msg1);
 
 #ifdef __GNU_LIBRARY__
 	extern char *__progname;
-	printf("%s\n%s terminated\n", msg1, __progname);
+	printf("%s terminated", __progname);
 #else
-	printf("%s\n%s\n", msg1, msg2);
+	printf("%s", msg2);
 #endif
 
 	// Try very hard to exit.  Note that signals may be blocked preventing

--- a/libssp/ssp.c
+++ b/libssp/ssp.c
@@ -1,0 +1,87 @@
+/* Stack protector support.
+	 Copyright (C) 2005-2017 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+In addition to the permissions in the GNU General Public License, the
+Free Software Foundation gives you unlimited permission to link the
+compiled version of this file into combinations with other programs,
+and to distribute those combinations without any restriction coming
+from the use of this file.  (The General Public License restrictions
+do apply in other respects; for example, they cover modification of
+the file, and distribution when not linked into a combine
+executable.)
+
+GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.  */
+
+
+#include <stdio.h>
+#include <unistd.h>
+
+void *__stack_chk_guard = 0;
+
+void __guard_setup(void)
+{
+	unsigned char *p;
+
+	if (__stack_chk_guard != 0)
+	{
+		return;
+	}
+
+	// If a random generator can't be used, the protector switches the guard
+	//	 to the "terminator canary".
+	p = (unsigned char *)&__stack_chk_guard;
+	p[sizeof(__stack_chk_guard)-1] = 255;
+	p[sizeof(__stack_chk_guard)-2] = '\n';
+	p[0] = 0;
+}
+
+static void fail(const char *msg1, const char *msg2)
+{
+	// Print error message directly to the tty. This avoids Bad Things
+	//   happening if stderr is redirected.
+
+#ifdef __GNU_LIBRARY__
+	extern char *__progname;
+	printf("%s\n%s terminated\n", msg1, __progname);
+#else
+	printf("%s\n%s\n", msg1, msg2);
+#endif
+
+	// Try very hard to exit.  Note that signals may be blocked preventing
+	//   the first two options from working.  The use of volatile is here to
+	//   prevent optimizers from "knowing" that __builtin_trap is called first,
+	//   and that it doesn't return, and so "obviously" the rest of the code
+	//   is dead.
+	_exit(134);
+}
+
+void (*guard)(void) __attribute__((section (".ctors"))) = __guard_setup;
+
+void __stack_chk_fail(void)
+{
+	fail("*** stack smashing detected ***: ", "stack smashing detected: terminated");
+}
+
+void __chk_fail(void)
+{
+	fail("*** buffer overflow detected ***: ", "buffer overflow detected: terminated");
+}

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -1,5 +1,5 @@
 ifeq ($(LIBTRANSISTOR_HOME),)
-    LIBTRANSISTOR_HOME := $(realpath "./")
+    LIBTRANSISTOR_HOME := $(realpath ./)
 else
     LIBTRANSISTOR_HOME := $(realpath $(LIBTRANSISTOR_HOME))
 endif
@@ -8,13 +8,13 @@ LD := ld.lld$(LLVM_POSTFIX)
 CC := clang$(LLVM_POSTFIX)
 AS := llvm-mc$(LLVM_POSTFIX)
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T $(LIBTRANSISTOR_HOME)/link.T
-CC_FLAGS := -g -fPIC -fno-stack-protector -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I "$(LIBTRANSISTOR_HOME)/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/sys/switch/include/" -Weverything -Wno-missing-prototypes -Wno-strict-prototypes -Wno-sign-conversion -Wno-missing-variable-declarations -Wno-unused-parameter -Wno-cast-align -Wno-padded -Wno-cast-qual -Wno-gnu-binary-literal -Werror-implicit-function-declaration
+CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I "$(LIBTRANSISTOR_HOME)/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/sys/switch/include/" -I$(LIBTRANSISTOR_HOME)/libssp/include -Weverything -Wno-missing-prototypes -Wno-strict-prototypes -Wno-sign-conversion -Wno-missing-variable-declarations -Wno-unused-parameter -Wno-cast-align -Wno-padded -Wno-cast-qual -Wno-gnu-binary-literal -Werror-implicit-function-declaration
 CFLAGS := $(CC_FLAGS) # for compatiblity
 AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch
 PYTHON2 := python2
 MEPHISTO := ctu
 RUBY := ruby
-LIBTRANSISTOR_COMMON_LIBS := $(LIBTRANSISTOR_HOME)/newlib/aarch64-none-switch/newlib/libc.a
+LIBTRANSISTOR_COMMON_LIBS := $(LIBTRANSISTOR_HOME)/newlib/aarch64-none-switch/newlib/libc.a $(LIBTRANSISTOR_HOME)/libssp/libssp.a
 LIBTRANSISTOR_NRO_LIB := $(LIBTRANSISTOR_HOME)/build/lib/libtransistor.nro.a
 LIBTRANSISTOR_NSO_LIB := $(LIBTRANSISTOR_HOME)/build/lib/libtransistor.nso.a
 LIBTRANSISTOR_NRO_LDFLAGS := --whole-archive $(LIBTRANSISTOR_NRO_LIB) --no-whole-archive $(LIBTRANSISTOR_COMMON_LIBS)

--- a/test/test_ssp.c
+++ b/test/test_ssp.c
@@ -1,29 +1,4 @@
-#include <libtransistor/nx.h>
-#include <stdio.h>
-
-#include <ssp/ssp.h>
-
-#define make_ip(a,b,c,d)	((a) | ((b) << 8) | ((c) << 16) | ((d) << 24))
-
-static FILE customout;
-static int sck;
-
-const struct sockaddr_in server_addr =
-{
-	.sin_family = AF_INET,
-	.sin_port = htons(2991),
-	.sin_addr = {
-		.s_addr = make_ip(192,168,121,131)
-	}
-};
-
-int stdout_debug(struct _reent *reent, void *v, const char *ptr, int len)
-{
-	bsd_send(sck, ptr, len, 0);
-	return len;
-}
-
-void explode_stack()
+int main()
 {
 	char buffer[10];
 	
@@ -40,45 +15,6 @@ void explode_stack()
 
 		buffer[i] = (char)i;
 	}
-}
-
-int main()
-{
-	svcSleepThread(100000000);
-
-	if(sm_init() != RESULT_OK)
-		return 1;
-
-	if(bsd_init() != RESULT_OK)
-	{
-		sm_finalize();
-		return 1;
-	}
-
-	sck = bsd_socket(2, 1, 6); // AF_INET, SOCK_STREAM, PROTO_TCP
-	if(sck < 0)
-	{
-		bsd_finalize();
-		sm_finalize();
-		return 1;
-	}
-
-	if(bsd_connect(sck, (struct sockaddr*) &server_addr, sizeof(server_addr)) < 0)
-	{
-		bsd_finalize();
-		sm_finalize();
-		return 1;
-	}
-
-	// this exact sequence will redirect stdout to socket
-	printf("_"); // init stdout
-	customout._write = stdout_debug;
-	customout._flags = __SWR | __SNBF;
-	customout._bf._base = (void*)1;
-	stdout = &customout;
-	stderr = &customout;
-
-	explode_stack();
 
 	return 0;
 }

--- a/test/test_ssp.c
+++ b/test/test_ssp.c
@@ -1,0 +1,84 @@
+#include <libtransistor/nx.h>
+#include <stdio.h>
+
+#include <ssp/ssp.h>
+
+#define make_ip(a,b,c,d)	((a) | ((b) << 8) | ((c) << 16) | ((d) << 24))
+
+static FILE customout;
+static int sck;
+
+const struct sockaddr_in server_addr =
+{
+	.sin_family = AF_INET,
+	.sin_port = htons(2991),
+	.sin_addr = {
+		.s_addr = make_ip(192,168,121,131)
+	}
+};
+
+int stdout_debug(struct _reent *reent, void *v, const char *ptr, int len)
+{
+	bsd_send(sck, ptr, len, 0);
+	return len;
+}
+
+void explode_stack()
+{
+	char buffer[10];
+	
+	for (int i = 0; i <= 10; i++)
+	{
+		// When compiled with stack protector support, this line
+		//   will print something to the effect of:
+		//
+		//   *** stack smashing detected ***: <unknown> terminated
+		//   Aborted (core dumped)
+		//
+		//   when i == 10, because 10 is an out of bounds write.
+		//   This will throw a SIGABRT, retruning code 134.
+
+		buffer[i] = (char)i;
+	}
+}
+
+int main()
+{
+	svcSleepThread(100000000);
+
+	if(sm_init() != RESULT_OK)
+		return 1;
+
+	if(bsd_init() != RESULT_OK)
+	{
+		sm_finalize();
+		return 1;
+	}
+
+	sck = bsd_socket(2, 1, 6); // AF_INET, SOCK_STREAM, PROTO_TCP
+	if(sck < 0)
+	{
+		bsd_finalize();
+		sm_finalize();
+		return 1;
+	}
+
+	if(bsd_connect(sck, (struct sockaddr*) &server_addr, sizeof(server_addr)) < 0)
+	{
+		bsd_finalize();
+		sm_finalize();
+		return 1;
+	}
+
+	// this exact sequence will redirect stdout to socket
+	printf("_"); // init stdout
+	customout._write = stdout_debug;
+	customout._flags = __SWR | __SNBF;
+	customout._bf._base = (void*)1;
+	stdout = &customout;
+	stderr = &customout;
+
+	explode_stack();
+
+	return 0;
+}


### PR DESCRIPTION
Integrated SSP into crt0_common. Support for bounds checking on memcpy etc. is not yet available. Add test run_ssp_test to demonstrate SSP