### PR TITLE
Makefile cleanup

### DIFF
--- a/libssp/Makefile
+++ b/libssp/Makefile
@@ -7,14 +7,14 @@ ifneq ($(CC_FOR_TARGET),)
 CC := $(CC_FOR_TARGET)
 endif
 
-ifneq ($(CC_FLAGS_FOR_TARGET),)
-CC_FLAGS := $(CC_FLAGS_FOR_TARGET)
+ifneq ($(CFLAGS_FOR_TARGET),)
+CFLAGS := $(CFLAGS_FOR_TARGET)
 endif
 
 .SUFFIXES: # disable built-in rules
 
 %.o: %.c
-	@$(CC) $(CC_FLAGS) -c -o $@ $<
+	@$(CC) $(CFLAGS) -c -o $@ $<
 	@echo [CC] $@
 
 all: libssp.a

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -4,13 +4,20 @@ else
     LIBTRANSISTOR_HOME := $(realpath $(LIBTRANSISTOR_HOME))
 endif
 
+SYS_INCLUDES := -isystem $(LIBTRANSISTOR_HOME)/newlib/newlib/libc/include/ -isystem $(LIBTRANSISTOR_HOME)/newlib/newlib/libc/sys/switch/include/
+INCLUDES := $(SYS_INCLUDES) -I$(LIBTRANSISTOR_HOME)/include/ -I$(LIBTRANSISTOR_HOME)/libssp/include
+WARNINGS := -Wall -Wextra
+
 LD := ld.lld$(LLVM_POSTFIX)
 CC := clang$(LLVM_POSTFIX)
 CXX := clang++$(LLVM_POSTFIX)
 AS := llvm-mc$(LLVM_POSTFIX)
+AR := llvm-ar$(LLVM_POSTFIX)
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T $(LIBTRANSISTOR_HOME)/link.T
-CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -target aarch64-none-linux-gnu -O0 -mtune=cortex-a53 -I "$(LIBTRANSISTOR_HOME)/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/include/" -isystem "$(LIBTRANSISTOR_HOME)/newlib/newlib/libc/sys/switch/include/" -I$(LIBTRANSISTOR_HOME)/libssp/include -Weverything -Wno-missing-prototypes -Wno-strict-prototypes -Wno-sign-conversion -Wno-missing-variable-declarations -Wno-unused-parameter -Wno-cast-align -Wno-padded -Wno-cast-qual -Wno-gnu-binary-literal -Werror-implicit-function-declaration -Wno-format-pedantic
-CFLAGS := $(CC_FLAGS) # for compatiblity
+CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -O0 -mtune=cortex-a53 -target aarch64-none-linux-gnu -nostdlib -nostdinc $(INCLUDES) $(WARNINGS)
+AR_FLAGS := rcs
+# for compatiblity
+CFLAGS := $(CC_FLAGS)
 AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch
 PYTHON2 := python2
 MEPHISTO := ctu

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -14,7 +14,7 @@ CXX := clang++$(LLVM_POSTFIX)
 AS := llvm-mc$(LLVM_POSTFIX)
 AR := llvm-ar$(LLVM_POSTFIX)
 LD_FLAGS := -Bsymbolic --shared --emit-relocs --no-gc-sections --no-undefined -T $(LIBTRANSISTOR_HOME)/link.T
-CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -O0 -mtune=cortex-a53 -target aarch64-none-linux-gnu -nostdlib -nostdinc $(INCLUDES) $(WARNINGS)
+CC_FLAGS := -g -fPIC -ffreestanding -fexceptions -O0 -mtune=cortex-a53 -target aarch64-none-linux-gnu -nostdlib -nostdlibinc $(INCLUDES) $(WARNINGS)
 AR_FLAGS := rcs
 # for compatiblity
 CFLAGS := $(CC_FLAGS)


### PR DESCRIPTION
Consolidate multiple CFLAGS into a single definition and clean other defines. Split very long rules into multiple lines for readability. Now enforcing -nostdinc. Travis and builds will be broken until newlib PR is merged adding missing header files.