### PR TITLE
Disable multilib support from newlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ $(LIBTRANSISTOR_NSO_LIB): $(LIBTRANSISTOR_HOME)/build/lib/crt0.nso.o $(libtransi
 	$(AR) $(AR_FLAGS) $@ $+
 
 $(LIBTRANSISTOR_HOME)/newlib/Makefile:
-	cd $(LIBTRANSISTOR_HOME)/newlib; ./configure --target=aarch64-none-switch --without-rdimon
+	cd $(LIBTRANSISTOR_HOME)/newlib; ./configure --disable-multilib --target=aarch64-none-switch --without-rdimon
 
 $(LIBTRANSISTOR_HOME)/newlib/aarch64-none-switch/newlib/libc.a: $(LIBTRANSISTOR_HOME)/newlib/Makefile
 	$(MAKE) -C $(LIBTRANSISTOR_HOME)/newlib/


### PR DESCRIPTION
avoids errors when compiling aarch64 ASM with armv7 assembler