### PR TITLE
Disable stack protector for libssp and crt0_common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ $(LIBTRANSISTOR_HOME)/build/test/%.o: $(LIBTRANSISTOR_HOME)/test/%.c
 	mkdir -p $(@D)
 	$(CC) $(CC_FLAGS) -c -o $@ $<
 
+# Disable stack protector for crt0_common
+$(LIBTRANSISTOR_HOME)/build/lib/crt0_common.o: $(LIBTRANSISTOR_HOME)/lib/crt0_common.c
+	mkdir -p $(@D)
+	$(CC) $(CC_FLAGS) -fno-stack-protector -c -o $@ $<
+
 $(LIBTRANSISTOR_HOME)/build/lib/%.o: $(LIBTRANSISTOR_HOME)/lib/%.c
 	mkdir -p $(@D)
 	$(CC) $(CC_FLAGS) -c -o $@ $<

--- a/libssp/Makefile
+++ b/libssp/Makefile
@@ -14,7 +14,7 @@ endif
 .SUFFIXES: # disable built-in rules
 
 %.o: %.c
-	@$(CC) $(CFLAGS) -c -o $@ $<
+	@$(CC) $(CFLAGS) -fno-stack-protector -c -o $@ $<
 	@echo [CC] $@
 
 all: libssp.a


### PR DESCRIPTION
Those two can't have the stack_protector enabled, since they set it up themselves. When multiple flags concerning stack protection conflict, gcc choses the last one, so we use this to enforce a disabled stack protection scheme.