### PR TITLE
Tell GDB about BSS relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Remote debugging using localhost:24689
 warning: No executable has been specified and target does not support
 determining executable automatically.  Try using the "file" command.
 0x0000007100000080 in ?? ()
-(gdb) add-symbol-file <path-to-libtransistor>/build/test/<binary>.nro.so 0x7100000000
+(gdb) add-symbol-file <path-to-libtransistor>/build/test/<binary>.nro.so 0x7100000000 -s .bss 0x7100000000
 add symbol table from file "<path-to-libtransistor>/build/test/<binary>.nro.so" at
 	.text_addr = 0x7100000000
+	.bss_addr = 0x7100000000
 (y or n) y
 Reading symbols from <path-to-libtransistor>/build/test/<binary>.nro.so...done.
 (gdb) 


### PR DESCRIPTION
Otherwise, mephisto can't find the stuff in the BSS, leading to the debugger's loss of hair.