### PR TITLE
Change the parameters of start

### DIFF
--- a/lib/crt0.nro.S
+++ b/lib/crt0.nro.S
@@ -41,7 +41,7 @@ _mod_header:
 start:
         sub sp, sp, 0x10
         stp x29, x30, [sp]
-        adrp x1, _start // aslr base
+        adrp x3, _start // aslr base
         bl _libtransistor_start
         ldp x29, x30, [sp], 0x10
         ret

--- a/lib/crt0.nso.S
+++ b/lib/crt0.nso.S
@@ -37,7 +37,7 @@ _mod_header:
 
 .section .text, "e"
 start:
-        adrp x1, _start // aslr base
+        adrp x3, _start // aslr base
 	bl _libtransistor_start
 loop:
 	b loop

--- a/lib/crt0_common.c
+++ b/lib/crt0_common.c
@@ -158,12 +158,17 @@ static int bsslog_write(struct _reent *reent, void *v, const char *ptr, int len)
 
 static jmp_buf exit_jmpbuf;
 static int exit_value;
+static thread_h MAIN_HANDLE;
 
-int _libtransistor_start(libtransistor_context_t *ctx, void *aslr_base) {
+int _libtransistor_start(void *exception_info_ptr, thread_h main_handle, libtransistor_context_t *ctx, void *aslr_base) {
 	if(relocate(aslr_base)) {
 		return -4;
 	}
 	
+	MAIN_HANDLE = main_handle;
+
+	dbg_printf("exception_ptr: %x", exception_info_ptr);
+	dbg_printf("main handle: %x", main_handle);
 	dbg_printf("aslr base: %p", aslr_base);
 	dbg_printf("ctx: %p", ctx);
 

--- a/projects/ace_loader/nro.c
+++ b/projects/ace_loader/nro.c
@@ -28,7 +28,7 @@ extern thread_h aceloader_main_thread_handle;
 
 uint64_t nro_start()
 {
-	uint64_t (*entry)(libtransistor_context_t*) = nro_base + 0x80;
+	uint64_t (*entry)(void *, thread_h, libtransistor_context_t*) = nro_base + 0x80;
 	uint64_t ret;
 
 	// generate memory block
@@ -73,7 +73,7 @@ uint64_t nro_start()
 	*(void**)(get_tls() + 0x1f8) = NULL;
 
 	// run NRO
-	ret = entry(&loader_context);
+	ret = entry(NULL, aceloader_main_thread_handle, &loader_context);
 
 	// Restore TLS
 	*tls_userspace_pointer = tls_backup;


### PR DESCRIPTION
On the switch, `start` takes two parameters : an exception pointer, and a handle to the main thread. 
For libtransistor, we'll also add a third one: a context handle. This should allow ace_loader to start apps expecting the usual switch treatment, while still providing the context to libtransistor binaries.

It also allows us to get a handle to the main_thread, which doesn't seem to be possible otherwise, short of putting it in the context.

Should be merged together with https://github.com/kgsws/ace_loader/pull/8 and https://github.com/reswitched/pegaswitch/pull/65