### PR TITLE
Implement exit syscall properly

### DIFF
--- a/lib/crt0.nro.S
+++ b/lib/crt0.nro.S
@@ -52,13 +52,6 @@ _get_module_header:
         add x0, x0, #:lo12:_mod_header
         ret
         
-.global _exit
-_exit:
-        //ldr x1, __crt0_exit_frame
-        //ldp x29, x30, [x1]
-        //ret
-        b _exit
-        
 .section .bss
 __crt0_exit_frame:       
         .quad 0

--- a/lib/crt0.nso.S
+++ b/lib/crt0.nso.S
@@ -40,8 +40,6 @@ start:
         adrp x1, _start // aslr base
 	bl _libtransistor_start
 loop:
-.global _exit
-_exit:  
 	b loop
 
 .global _get_module_header


### PR DESCRIPTION
Uses setjmp/longjmp to implement exit.