### PR TITLE
use full path to nro file relative to the helper script

### DIFF
--- a/test_helpers/bsd.rb
+++ b/test_helpers/bsd.rb
@@ -3,7 +3,7 @@ require "socket"
 server = TCPServer.new(5555)
 
 child = fork do
-  exec(ARGV[0], "--load-nro", "build/test/test_bsd.nro", "--enable-sockets")
+  exec(ARGV[0], "--load-nro", File.expand_path(File.dirname(__FILE__)) + "/../build/test/test_bsd.nro", "--enable-sockets")
 end
 
 client = server.accept


### PR DESCRIPTION
this will fix instances where mephisto is run via a wrapper script and is not in the same working directory