### PR TITLE
Use python3 for elf2nxo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ addons:
       - lld-5.0
       - liblz4-dev
       - graphviz
+      - python3
+      - python3-pip
 
 install:
     # Download and install recent cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
   - cd ..
   - git clone https://github.com/reswitched/Mephisto.git
   - cd Mephisto
-  - sudo pip3 install -r  requirements.txt
+  - sudo pip2 install -r  requirements.txt
   - make
   - cd ..
   - sudo pip3 install -r  requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,10 +57,10 @@ before_script:
   - cd ..
   - git clone https://github.com/reswitched/Mephisto.git
   - cd Mephisto
-  - sudo pip2 install -r  requirements.txt
+  - sudo pip3 install -r  requirements.txt
   - make
   - cd ..
-  - sudo pip2 install -r  requirements.txt
+  - sudo pip3 install -r  requirements.txt
 script:  make LLVM_POSTFIX=-5.0 LD=ld.lld-5.0 && make -C projects/ace_loader LLVM_POSTFIX=-5.0 LD=ld.lld-5.0 && make run_tests MEPHISTO=./Mephisto/ctu
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, clone the repo with
 git clone --recursive https://github.com/reswitched/libtransistor
 ```
 
-You will need Python 2 and the python packages listed in [`requirements.txt`](https://github.com/reswitched/libtransistor/blob/master/requirements.txt). You'll also need clang and lld >=5.0 (llvm linker).
+You will need Python 3 and the python packages listed in [`requirements.txt`](https://github.com/reswitched/libtransistor/blob/master/requirements.txt). You'll also need clang and lld >=5.0 (llvm linker).
 
 You *should* just be able to run `make`. If that doesn't work, submit an issue (or pull request). This will produce a number of `nro` and `nso` files in `build/test/`. These are binaries for the Nintendo Switch. NRO files are relocatable shared objects suitable for use with [ROhan](https://reswitched.tech/rohan). Both NRO and NSO binaries can be run under Mephisto, but NSO binaries don't get relocated properly at the moment and will crash pretty quickly.
 

--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -19,7 +19,7 @@ AR_FLAGS := rcs
 # for compatiblity
 CFLAGS := $(CC_FLAGS)
 AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch
-PYTHON2 := python2
+PYTHON3 := python3
 MEPHISTO := ctu
 RUBY := ruby
 COMPILER_RT_BUILTINS_LIB := $(LIBTRANSISTOR_HOME)/build/compiler-rt/lib/linux/libclang_rt.builtins-aarch64.a
@@ -30,7 +30,7 @@ LIBTRANSISTOR_NRO_LDFLAGS := --whole-archive $(LIBTRANSISTOR_NRO_LIB) --no-whole
 LIBTRANSISTOR_NSO_LDFLAGS := --whole-archive $(LIBTRANSISTOR_NSO_LIB) --no-whole-archive $(LIBTRANSISTOR_COMMON_LIBS)
 
 %.nro: %.nro.so
-	$(PYTHON2) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nro
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nro
 
 %.nso: %.nso.so
-	$(PYTHON2) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nso
+	$(PYTHON3) $(LIBTRANSISTOR_HOME)/tools/elf2nxo.py $< $@ nso

--- a/tools/elf2nxo.py
+++ b/tools/elf2nxo.py
@@ -6,18 +6,19 @@ from elftools.elf.relocation import RelocationSection
 from elftools.elf.sections import *
 import lz4.block
 
-R_AARCH64_ABS64	 = 257
-R_AARCH64_ABS32	 = 258
-R_AARCH64_ABS16	 = 259
+R_AARCH64_ABS64 = 257
+R_AARCH64_ABS32 = 258
+R_AARCH64_ABS16 = 259
 R_AARCH64_PREL64 = 260
 R_AARCH64_PREL32 = 261
 R_AARCH64_PREL16 = 262
+
 
 def main(input, output, format='nro'):
 	format = format.lower()
 	assert format in ('nro', 'nso')
 
-	with file(input, 'rb') as f:
+	with open(input, 'rb') as f:
 		elffile = ELFFile(f)
 		elffile.iter_sections_by_type = lambda type: (x for x in elffile.iter_sections() if isinstance(x, type))
 
@@ -29,12 +30,13 @@ def main(input, output, format='nro'):
 				symbols[sym.name] = sectaddr + sym['st_value']
 				symbolList.append(sym.name)
 
-		textCont, rodataCont, relaDynCont, dataCont, dynamicCont = [elffile.get_section_by_name(x).data() for x in ('.text', '.rodata', '.rela.dyn', '.data', '.dynamic')]
+		textCont, rodataCont, relaDynCont, dataCont, dynamicCont = [elffile.get_section_by_name(x).data() for x in (
+		'.text', '.rodata', '.rela.dyn', '.data', '.dynamic')]
 		csec = dict(text=textCont, rodata=rodataCont, relaDyn=relaDynCont, data=dataCont, dynamic=dynamicCont)
 
 		def replace(tgt, offset, data):
 			orig = csec[tgt]
-			csec[tgt] = orig[:offset] + data + orig[offset+len(data):]
+			csec[tgt] = orig[:offset] + data + orig[offset + len(data):]
 
 		for x in elffile.iter_sections_by_type(RelocationSection):
 			tgtsect = elffile.get_section(x['sh_info'])
@@ -46,70 +48,73 @@ def main(input, output, format='nro'):
 				if not symname.startswith('NORELOC_'):
 					continue
 
-				type = iter['r_info_type']
-				if type == R_AARCH64_PREL32:
-					replace(tgt, iter['r_offset'], struct.pack('<i', symbols[symname] + iter['r_addend'] - (tgtsect['sh_addr'] + iter['r_offset'])))
-				elif type == R_AARCH64_ABS32:
+				reloc_type = iter['r_info_type']
+				if reloc_type == R_AARCH64_PREL32:
+					replace(tgt, iter['r_offset'], struct.pack('<i', symbols[symname] + iter['r_addend'] - (
+							tgtsect['sh_addr'] + iter['r_offset'])))
+				elif reloc_type == R_AARCH64_ABS32:
 					replace(tgt, iter['r_offset'], struct.pack('<I', symbols[symname] + iter['r_addend']))
 				else:
-					print 'Unknown relocation type!', type
+					print('Unknown relocation type!', reloc_type)
 					assert False
 
 		text, rodata, data = csec['text'], csec['rodata'], csec['data']
 
-                if len(rodata) & 0x7:
-                        rodata += '\0' * (0x8 - (len(rodata) & 0x7))
+		if len(rodata) & 0x7:
+			rodata += '\0'.encode() * (0x8 - (len(rodata) & 0x7))
 
-                rodata += csec['relaDyn']
+		rodata += csec['relaDyn']
 
-                if len(data) & 0x7:
-                        data += '\0' * (0x8 - (len(data) & 0x7))
+		if len(data) & 0x7:
+			data += '\0'.encode() * (0x8 - (len(data) & 0x7))
 
-                data += csec['dynamic']
-                
+		data += csec['dynamic']
+
 		if len(text) & 0xFFF:
-			text += '\0' * (0x1000 - (len(text) & 0xFFF))
+			text += '\0'.encode() * (0x1000 - (len(text) & 0xFFF))
 		if len(rodata) & 0xFFF:
-			rodata += '\0' * (0x1000 - (len(rodata) & 0xFFF))
+			rodata += '\0'.encode() * (0x1000 - (len(rodata) & 0xFFF))
 		if len(data) & 0xFFF:
-			data += '\0' * (0x1000 - (len(data) & 0xFFF))
+			data += '\0'.encode() * (0x1000 - (len(data) & 0xFFF))
 
-                bssSize = symbols['NORELOC_BSS_END_'] - symbols['NORELOC_BSS_START_']
-                if bssSize & 0xFFF:
-                        bssSize += 0x1000 - (bssSize & 0xFFF)
-                
+		bssSize = symbols['NORELOC_BSS_END_'] - symbols['NORELOC_BSS_START_']
+		if bssSize & 0xFFF:
+			bssSize += 0x1000 - (bssSize & 0xFFF)
+
 		if format == 'nro':
-			#text = text[0x80:]
-			with file(output, 'wb') as fp:
+			# text = text[0x80:]
+			with open(output, 'wb') as fp:
 				fp.write(struct.pack('<IIII', 0, len(text) + len(rodata) + 8, 0, 0))
-				fp.write('NRO0')
+				fp.write('NRO0'.encode())
 				fp.write(struct.pack('<III', 0, len(text) + len(rodata) + len(data), 0))
 				fp.write(struct.pack('<IIII', 0, len(text), len(text), len(rodata)))
 				fp.write(struct.pack('<IIII', len(text) + len(rodata), len(data), bssSize, 0))
-				fp.write('\0' * 0x40)
+				fp.write('\0'.encode() * 0x40)
 				fp.write(text[0x80:])
 				fp.write(rodata)
 				fp.write(data)
 		else:
-			with file(output, 'wb') as fp:
+			with open(output, 'wb') as fp:
 				ctext, crodata, cdata = [lz4.block.compress(x, store_size=False) for x in (text, rodata, data)]
 
-				fp.write('NSO0')
-				fp.write('\0' * 0xC)
+				fp.write('NSO0'.encode())
+				fp.write('\0'.encode() * 0xC)
 
 				off = 0x101
 				fp.write(struct.pack('<IIII', off, 0, len(text), 0))
 				off += len(ctext)
 				fp.write(struct.pack('<IIII', off, len(text), len(rodata), 0))
 				off += len(crodata)
-				fp.write(struct.pack('<IIII', off, len(text) + len(rodata), len(data), symbols['NORELOC_BSS_END_'] - symbols['NORELOC_BSS_START_']))
-				fp.write('\0' * 0x20)
+				fp.write(struct.pack('<IIII', off, len(text) + len(rodata), len(data),
+									 symbols['NORELOC_BSS_END_'] - symbols['NORELOC_BSS_START_']))
+				fp.write('\0'.encode() * 0x20)
 				fp.write(struct.pack('<IIII', len(ctext), len(crodata), len(cdata), 0))
-				fp.write('\0' * 0x91)
-				
+				fp.write('\0'.encode() * 0x91)
+
 				fp.write(ctext)
 				fp.write(crodata)
 				fp.write(cdata)
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
 	sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
As discussed quickly on the Discord, this PR is an update to elf2nxo to use Python 3 instead of Python 2.

Some variables were also renamed to avoid shadowing Python builtin functions.