### PR TITLE
Added some functionality to the time ipc module

### DIFF
--- a/include/libtransistor/ipc/time.h
+++ b/include/libtransistor/ipc/time.h
@@ -9,6 +9,7 @@
 
 ipc_object_t time_systemclock_user;
 ipc_object_t time_systemclock_network;
+ipc_object_t time_systemclock_local;
 
 /**
 * @brief Initialize Time service
@@ -16,11 +17,14 @@ ipc_object_t time_systemclock_network;
 result_t time_init();
 
 /**
-* @brief Get the current system time
+* @brief Get the current system time from one of the systemclocks
 */
 result_t time_systemclock_get_current_time(ipc_object_t systemclock, uint64_t *time);
+
+/**
+* @brief Set the current system time for one of the systemclocks
+*/
 result_t time_systemclock_set_current_time(ipc_object_t systemclock, uint64_t *time);
-//result_t time_get_current_time(uint64_t *time);
 
 /**
 * @brief Finalize Time service

--- a/include/libtransistor/ipc/time.h
+++ b/include/libtransistor/ipc/time.h
@@ -7,6 +7,9 @@
 
 #include<libtransistor/types.h>
 
+ipc_object_t time_systemclock_user;
+ipc_object_t time_systemclock_network;
+
 /**
 * @brief Initialize Time service
 */
@@ -15,7 +18,9 @@ result_t time_init();
 /**
 * @brief Get the current system time
 */
-result_t time_get_current_time(uint64_t *time);
+result_t time_systemclock_get_current_time(ipc_object_t systemclock, uint64_t *time);
+result_t time_systemclock_set_current_time(ipc_object_t systemclock, uint64_t *time);
+//result_t time_get_current_time(uint64_t *time);
 
 /**
 * @brief Finalize Time service

--- a/lib/ipc/time.c
+++ b/lib/ipc/time.c
@@ -103,17 +103,6 @@ result_t time_systemclock_set_current_time(ipc_object_t systemclock, uint64_t *t
 	return ipc_send(systemclock, &rq, &rs);
 }
 
-//result_t time_get_current_time(uint64_t *time) {
-//	ipc_request_t rq = ipc_default_request;
-//	ipc_response_fmt_t rs = ipc_default_response_fmt;
-//
-//	rq.request_id = 0;
-//	rs.raw_data = time;
-//	rs.raw_data_size = sizeof(*time);
-//
-//	return ipc_send(time_systemclock_user, &rq, &rs);
-//}
-
 static void time_force_finalize() {
 	ipc_close(time_systemclock_user);
 	ipc_close(time_systemclock_network);

--- a/lib/syscalls/syscalls.c
+++ b/lib/syscalls/syscalls.c
@@ -220,7 +220,7 @@ int _gettimeofday_r(struct _reent *reent, struct timeval *__restrict p, void *__
 		atexit(time_finalize);
 	}
 	
-	if ((res = time_get_current_time(&time)) != RESULT_OK) {
+	if ((res = time_systemclock_get_current_time(time_systemclock_user, &time)) != RESULT_OK) {
 		reent->_errno = -EINVAL;
 		return -1;
 	}


### PR DESCRIPTION
in time.c / time.h:
- 	removed: static isystemclock_object;
- 	added: time_systemclock_user;
- 	added: time_systemclock_network;
- 	added: time_systemclock_local;
- 	removed: time_get_current_time(time);
- 	added: time_systemclock_get_current_time(systemclock, time);
- 	added: time_systemclock_set_current_time(systemclock, time);

in syscalls.c:
- 	changed the time_get_current_time() to use
- 	time_systemclock_get_current_time(time_systemclock_user, time);

Made it possible to interface with all the isystemclocks the time service has to offer.
Made it possible to set the time.