### PR TITLE
.gitattributes: ignore man pages in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.1 linguist-vendored
+*.2 linguist-vendored
+*.3 linguist-vendored
+*.4 linguist-vendored
+*.5 linguist-vendored


### PR DESCRIPTION
This file tells github to ignore the files ending in *.1 through *.5, which fixes the language reporting on the main repo page:

before:
![](https://i.imgur.com/mqYuSoI.png)

after:
![](https://i.imgur.com/nlENPwC.png)

There may be other filenames/paths that should be added to this file, but I think this fix to it appearing as Roff addresses the major one