### PR TITLE
Disallow building with root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(shell id -u), 0)
+   $(error "This script must not be run as root")
+endif
+
 include libtransistor.mk
 
 # for building newlib and sdl


### PR DESCRIPTION
Add an error message to prevent users from building Libtransistor with root. This has caused issues in the past. Closes #100