### PR TITLE
Fix make distclean and some minor make clean fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,5 @@ default: $(DIST)
 clean: clean_transistor clean_test
 	rm -rf $(LIBTRANSISTOR_HOME)/docs
 
-distclean: clean clean_newlib clean_compiler-rt clean_pthread clean_sdl2
+distclean: clean clean_newlib clean_compiler-rt clean_pthread clean_sdl2 clean_libcxx clean_liblzma clean_openlibm
+	rm -rf $(LIBTRANSISTOR_HOME)/dist

--- a/mk/libcxx.mk
+++ b/mk/libcxx.mk
@@ -95,3 +95,10 @@ $(BUILD_DIR)/libunwind/Makefile: $(DIST_LIBCXX) $(DIST_TRANSISTOR_SUPPORT)
 		-DLLVM_CONFIG_PATH=llvm-config$(LLVM_POSTFIX) \
 		-DCMAKE_SYSTEM_NAME=Linux \
 		-DCMAKE_INSTALL_PREFIX=$(LIBTRANSISTOR_HOME)
+
+# CLEAN RULES
+
+.PHONY: clean_libcxx clean
+
+clean_libcxx:
+	rm -rf $(BUILD_DIR)/libcxx $(BUILD_DIR)/libcxxabi $(BUILD_DIR)/libunwind

--- a/mk/openlibm.mk
+++ b/mk/openlibm.mk
@@ -44,4 +44,4 @@ dist_openlibm: $(DIST_OPENLIBM)
 .PHONY: clean_openlibm
 
 clean_openlibm:
-	rm -fr build/openlibm
+	rm -rf $(BUILD_DIR)/openlibm

--- a/mk/pthread.mk
+++ b/mk/pthread.mk
@@ -56,4 +56,4 @@ $(BUILD_DIR)/pthread/%.o: $(SOURCE_ROOT)/pthread/%.c $(pthread_BUILD_DEPS) $(DIS
 .PHONY: clean_pthread
 
 clean_pthread:
-	rm -fr build/pthread
+	rm -rf $(BUILD_DIR)/pthread

--- a/mk/sdl2.mk
+++ b/mk/sdl2.mk
@@ -37,4 +37,4 @@ dist_sdl2: $(LIB_DEP_SDL2)
 .PHONY: clean_sdl2
 
 clean_sdl2:
-	rm -rf build/sdl2 build/sdl2_install
+	rm -rf $(BUILD_DIR)/sdl2 $(BUILD_DIR)/sdl2_install


### PR DESCRIPTION
PR details
- This adds clean_libcxx to the libcxx makefile.
- This adds `clean_libcxx`, `clean_liblzma` and the deletion of the dist folder to `make distclean`.
- Changes some of the `rm -fr` to `rm -rf` for consistency.
- Changes uses of `build/` to `$(BUILD_DIR)` in cleaning sections.