### PR TITLE
Add make autodependencies

### DIFF
--- a/libtransistor.mk
+++ b/libtransistor.mk
@@ -32,7 +32,7 @@ CPP_INCLUDES := -isystem $(LIBTRANSISTOR_HOME)/include/c++/v1/
 LD_FLAGS := -Bsymbolic --shared --no-gc-sections --eh-frame-hdr --no-undefined -T $(LIBTRANSISTOR_HOME)/link.T \
 	-L $(LIBTRANSISTOR_HOME)/lib/
 
-CC_FLAGS := -g -fPIC -fexceptions -fuse-ld=lld -fstack-protector-strong -O3 -mtune=cortex-a53 -target aarch64-none-linux-gnu -nostdlib -nostdlibinc $(SYS_INCLUDES) -D__SWITCH__=1 -Wno-unused-command-line-argument
+CC_FLAGS := -MD -MP -g -fPIC -fexceptions -fuse-ld=lld -fstack-protector-strong -O3 -mtune=cortex-a53 -target aarch64-none-linux-gnu -nostdlib -nostdlibinc $(SYS_INCLUDES) -D__SWITCH__=1 -Wno-unused-command-line-argument
 CXX_FLAGS := $(CC_FLAGS) -std=c++11 -stdlib=libc++ -nodefaultlibs -nostdinc++ $(CPP_INCLUDES)
 AR_FLAGS := rcs
 AS_FLAGS := -arch=aarch64 -triple aarch64-none-switch


### PR DESCRIPTION
Add `-MD` and `-MP` flags:

+ `-MD` instructs Clang to generate a dependency file with a .d suffix as a side-effect of compilation when using -o. This includes tracking both system and user headers
+ `-MP` instructs Clang to generate phony targets for every dependency. The end result is that if a header is deleted or moved Make will not throw an error.

Closes #112 