### PR TITLE
fix(build): libunwind include

### DIFF
--- a/mk/transistor.mk
+++ b/mk/transistor.mk
@@ -5,7 +5,7 @@ libtransistor_OBJECT_FILES := $(addprefix $(BUILD_DIR)/transistor/,$(libtransist
 
 libtransistor_WARNINGS := -Wall -Wextra -Werror-implicit-function-declaration -Wno-unused-parameter -Wno-unused-command-line-argument -Werror-thread-safety
 
-libtransistor_BUILD_DEPS := $(DIST_NEWLIB) $(DIST_PTHREAD_HEADERS) $(DIST_PTHREAD) $(DIST_LIBLZMA) $(DIST_TRANSISTOR_HEADERS) $(DIST_TRANSISTOR_SUPPORT) $(DIST_LIBCXX)
+libtransistor_BUILD_DEPS := $(DIST_NEWLIB) $(DIST_PTHREAD_HEADERS) $(DIST_PTHREAD) $(DIST_LIBLZMA) $(DIST_TRANSISTOR_HEADERS) $(DIST_TRANSISTOR_SUPPORT) $(DIST_LIBCXX) $(DIST_LIBUNWIND)
 
 # ARCHIVE RULES
 


### PR DESCRIPTION
This seems to fix the error for Travis and I get when building `fatal error: 'libunwind.h' file not found`.

I was also wondering if it's possible to fixup [this](https://reswitchedweekly.github.io/Development-Setup/):
  - On brew 'python3' is just 'python' now
  - squashfs is required on mac (as on #142)